### PR TITLE
Fix bug that zero'd Puyallup populations

### DIFF
--- a/R/puyallup.R
+++ b/R/puyallup.R
@@ -8,7 +8,7 @@ puyallup_sim <- function(pop, nearshore_surv_adj = 1) {
     prespawner_prop
   holdingprespawn <- beverton_holt(sum(migrantprespawn), 0.872, 729726.40) *
     prespawner_prop
-  spawners <- beverton_holt(holdingprespawn, 0.971, 1139372348.62) *
+  spawners <- beverton_holt(sum(holdingprespawn), 0.971, 1139372348.62) *
     prespawner_prop
 
   ## Fecundity is age-dependent and assumes 50/50 sex ratio


### PR DESCRIPTION
Missed summing the `holdingprespawn` argument when calculating `spawners`. Multiplying by the proportion in each age class resulted in an unsustainable population, so the equilibrium was zero.